### PR TITLE
Add FetchMethod to resource.WebPage to track whether the resource

### DIFF
--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -109,11 +109,6 @@ func (s *scrapeServer) makeHeadlessFetcher(_ context.Context, ht http.RoundTripp
 		return err
 	}
 	s.headlessFetcher = hf
-	// if sbf, ok := s.urlFetcher.(*scrape.StorageBackedFetcher); ok {
-	// 	s.headlessFetcher, err = sbf.WithAlternateURLFetcher(ctx, hf)
-	// } else {
-	// 	s.headlessFetcher = hf
-	// }
 	return err
 }
 
@@ -174,6 +169,7 @@ func extractWithFetcher(fetcher fetch.URLFetcher) http.HandlerFunc {
 				w.WriteHeader(http.StatusUnprocessableEntity)
 			}
 		}
+		page.FetchMethod = resource.Headless
 		encoder := json.NewEncoder(w)
 		encoder.SetEscapeHTML(false)
 		if req.PrettyPrint {

--- a/resource/fetch_method.go
+++ b/resource/fetch_method.go
@@ -1,0 +1,19 @@
+package resource
+
+type FetchMethod int
+
+const (
+	Client FetchMethod = iota
+	Headless
+)
+
+func (f FetchMethod) String() string {
+	switch f {
+	case Client:
+		return "client"
+	case Headless:
+		return "headless"
+	default:
+		return "unknown"
+	}
+}

--- a/resource/fetch_method_test.go
+++ b/resource/fetch_method_test.go
@@ -1,0 +1,32 @@
+package resource
+
+import "testing"
+
+func TestFetchMethodString(t *testing.T) {
+	tests := []struct {
+		name string
+		f    FetchMethod
+		want string
+	}{
+		{
+			name: "Client",
+			f:    Client,
+			want: "client",
+		},
+		{
+			name: "Headless",
+			f:    Headless,
+			want: "headless",
+		},
+		{
+			name: "Unknown",
+			f:    3,
+			want: "unknown",
+		},
+	}
+	for _, tt := range tests {
+		if got := tt.f.String(); got != tt.want {
+			t.Errorf("[%s] FetchMethod.String() = %v, want %v", tt.name, got, tt.want)
+		}
+	}
+}

--- a/resource/web_page.go
+++ b/resource/web_page.go
@@ -12,14 +12,17 @@ import (
 
 type skippable string
 
-var (
+const (
 	CanonicalURL skippable = "canonical_url"
 	ContentText  skippable = "content_text"
 	OriginalURL  skippable = "original_url"
 	FetchTime    skippable = "fetch_time"
 	TTL          skippable = "ttl"
-	ErrNoTTL               = errors.New("TTL not set")
-	DefaultTTL             = 30 * 24 * time.Hour
+)
+
+var (
+	ErrNoTTL   = errors.New("TTL not set")
+	DefaultTTL = 30 * 24 * time.Hour
 )
 
 // experimental: the original WebPage struct embeds trafilatura.Metadata,
@@ -40,6 +43,7 @@ type WebPage struct { // The page that was requested by the caller
 	OriginalURL  string        `json:"original_url,omitempty"` // The canonical URL of the page
 	TTL          time.Duration `json:"-"`                      // Time to live for the resource
 	FetchTime    *time.Time    `json:"fetch_time,omitempty"`   // When the returned source was fetched
+	FetchMethod  FetchMethod   `json:"fetch_method,omitempty"` // Method used to fetch the page
 	Hostname     string        `json:"hostname,omitempty"`     // Hostname of the page
 	StatusCode   int           `json:"status_code,omitempty"`  // HTTP status code
 	Error        error         `json:"error,omitempty"`


### PR DESCRIPTION
was fetched via the build-in client or headless.