### PR TITLE
JWT generation and verifications

### DIFF
--- a/cmd/scrape-jwt-decode/main.go
+++ b/cmd/scrape-jwt-decode/main.go
@@ -1,0 +1,63 @@
+// scrape-jwt-decode verifies and decodes auth keys for the scrape service
+//
+// Run `scrape-jwt-decode -h` for complete help and command line options.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/efixler/envflags"
+	"github.com/efixler/scrape/internal/auth"
+)
+
+var (
+	flags      flag.FlagSet
+	signingKey *envflags.Value[*auth.HMACBase64Key]
+)
+
+func main() {
+	token := flags.Arg(0)
+	key := *signingKey.Get()
+	if len(key) == 0 {
+		slog.Error("No signing key provided")
+		os.Exit(1)
+	}
+	claims, err := auth.VerifyToken(key, token)
+	if err != nil {
+		slog.Error("Error verifying token, the token or signatore are invalid", "err", err)
+		os.Exit(1)
+	}
+	fmt.Println("\nThis JWT is valid. Claims:\n------")
+	fmt.Println(claims)
+
+}
+
+func init() {
+	flags.Init("scrape-jwt-encode", flag.ExitOnError)
+	flags.Usage = usage
+	envflags.EnvPrefix = "SCRAPE_"
+	signingKey = envflags.NewText("SIGNING_KEY", &auth.HMACBase64Key{})
+	signingKey.AddTo(&flags, "signing-key", "HS256 key to sign the JWT token")
+	flags.Parse(os.Args[1:])
+	if len(flags.Args()) == 0 {
+		slog.Error("Token is required")
+		usage()
+		os.Exit(1)
+	}
+}
+
+func usage() {
+	fmt.Println(`
+Generates JWT tokens for the scrape service. Also makes the signing key to use for the tokens.
+
+Usage: 
+-----
+scrape-jwt-decode [-signing-key keyval] token
+	`)
+
+	flags.PrintDefaults()
+}

--- a/cmd/scrape-jwt-decode/main.go
+++ b/cmd/scrape-jwt-decode/main.go
@@ -33,7 +33,6 @@ func main() {
 	}
 	fmt.Println("\nThis JWT is valid. Claims:\n------")
 	fmt.Println(claims)
-
 }
 
 func init() {

--- a/cmd/scrape-jwt-decode/main.go
+++ b/cmd/scrape-jwt-decode/main.go
@@ -28,7 +28,7 @@ func main() {
 	}
 	claims, err := auth.VerifyToken(key, token)
 	if err != nil {
-		slog.Error("Error verifying token, the token or signatore are invalid", "err", err)
+		slog.Error("Error verifying token, the token or signature are invalid", "err", err)
 		os.Exit(1)
 	}
 	fmt.Println("\nThis JWT is valid. Claims:\n------")
@@ -52,7 +52,10 @@ func init() {
 
 func usage() {
 	fmt.Println(`
-Generates JWT tokens for the scrape service. Also makes the signing key to use for the tokens.
+Verify and decode scrape JWT tokens.
+
+Signing key is required to verify the token signature. The signing key should be base64
+encoded and can be provided as a command line flag or environment variable.
 
 Usage: 
 -----

--- a/cmd/scrape-jwt-encode/main.go
+++ b/cmd/scrape-jwt-encode/main.go
@@ -1,0 +1,105 @@
+// keygen generates auth keys for the scrape service
+//
+// Run `scrape-keygen -h` for complete help and command line options.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"log/slog"
+
+	"github.com/efixler/envflags"
+	"github.com/efixler/scrape/internal/auth"
+)
+
+var (
+	flags      flag.FlagSet
+	expires    = time.Now().Add(24 * time.Hour * 365)
+	subject    string
+	audience   = "moz"
+	signingKey *envflags.Value[*auth.HMACBase64Key]
+	makeKey    bool
+)
+
+func main() {
+	if makeKey {
+		makeSigningKey()
+		return
+	}
+	makeToken()
+}
+
+func makeToken() {
+	if subject == "" {
+		slog.Error("Subject is required")
+		usage()
+		os.Exit(1)
+	}
+	claims, err := auth.NewClaims(
+		auth.ExpiresAt(expires),
+		auth.Subject(subject),
+		auth.Audience(audience),
+	)
+	if err != nil {
+		slog.Error("Error generating claims", "err", err)
+		os.Exit(1)
+	}
+	fmt.Println(claims)
+	key := *signingKey.Get()
+	if len(key) == 0 {
+		slog.Warn("No signing key provided, cannot sign token, exiting")
+		os.Exit(1)
+	}
+	slog.Info("Signing key", "key", key)
+	ss, err := claims.Sign(key)
+	if err != nil {
+		slog.Error("Error signing token", "err", err)
+		os.Exit(1)
+	}
+	fmt.Println("Token:", ss)
+}
+
+func makeSigningKey() {
+	key, err := auth.NewHS256SigningKey()
+	if err != nil {
+		slog.Error("Error generating signing key", "err", err)
+		os.Exit(1)
+	}
+	encoded, err := key.MarshalText()
+	if err != nil {
+		slog.Error("Error encoding signing key", "err", err)
+		os.Exit(1)
+	}
+	fmt.Println("Be sure to save this key, as it can't be re-generated:")
+	fmt.Println(string(encoded))
+}
+
+func init() {
+	flags.Init("scrape-keygen", flag.ExitOnError)
+	flags.Usage = usage
+	envflags.EnvPrefix = "SCRAPE_"
+	flags.BoolVar(&makeKey, "make-key", false, "Generate a new signing key")
+	flags.TextVar(&expires, "exp", expires, "Expiration date for the key, in RFC3339 format. Default is 1 year from now.")
+	flags.StringVar(&subject, "sub", "", "Subject (holder name) for the key (required)")
+	flags.StringVar(&audience, "aud", audience, "Audience (recipient) for the key")
+	signingKey = envflags.NewText("SIGNING_KEY", &auth.HMACBase64Key{})
+	signingKey.AddTo(&flags, "signing-key", "HS256 key to sign the JWT token")
+	flags.Parse(os.Args[1:])
+}
+
+func usage() {
+	fmt.Println(`
+Generates JWT tokens for the scrape service. Also makes the signing key to use for the tokens.
+
+Usage: 
+-----
+scrape-jwt-encode -sub subject [-signing-key key] [-exp expiration] [-aud audience]
+scrape-jwt-encode -make-key
+	`)
+
+	flags.PrintDefaults()
+}

--- a/cmd/scrape-jwt-encode/main.go
+++ b/cmd/scrape-jwt-encode/main.go
@@ -41,26 +41,27 @@ func makeToken() {
 	}
 	claims, err := auth.NewClaims(
 		auth.ExpiresAt(expires),
-		auth.Subject(subject),
-		auth.Audience(audience),
+		auth.WithSubject(subject),
+		auth.WithAudience(audience),
 	)
 	if err != nil {
 		slog.Error("Error generating claims", "err", err)
 		os.Exit(1)
 	}
+	fmt.Println("\nClaims:\n------")
 	fmt.Println(claims)
 	key := *signingKey.Get()
 	if len(key) == 0 {
 		slog.Warn("No signing key provided, cannot sign token, exiting")
 		os.Exit(1)
 	}
-	slog.Info("Signing key", "key", key)
 	ss, err := claims.Sign(key)
 	if err != nil {
 		slog.Error("Error signing token", "err", err)
 		os.Exit(1)
 	}
-	fmt.Println("Token:", ss)
+	fmt.Println("\nToken:\n-----")
+	fmt.Println(ss)
 }
 
 func makeSigningKey() {

--- a/cmd/scrape-jwt-encode/main.go
+++ b/cmd/scrape-jwt-encode/main.go
@@ -1,6 +1,6 @@
-// keygen generates auth keys for the scrape service
+// scrape-jwt-encode generates auth keys for the scrape service
 //
-// Run `scrape-keygen -h` for complete help and command line options.
+// Run `scrape-jwt-encode -h` for complete help and command line options.
 
 package main
 
@@ -80,7 +80,7 @@ func makeSigningKey() {
 }
 
 func init() {
-	flags.Init("scrape-keygen", flag.ExitOnError)
+	flags.Init("scrape-jwt-encode", flag.ExitOnError)
 	flags.Usage = usage
 	envflags.EnvPrefix = "SCRAPE_"
 	flags.BoolVar(&makeKey, "make-key", false, "Generate a new signing key")

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/efixler/webutil v0.0.0-20240331165905-2fd0e608a9e9
 	github.com/go-shiori/go-readability v0.0.0-20240204090920-819593fddc6b
 	github.com/go-sql-driver/mysql v1.8.1
+	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/markusmobius/go-domdistiller v0.0.0-20230515154422-71af71939ff3
 	github.com/markusmobius/go-trafilatura v1.5.1
 	github.com/mattn/go-sqlite3 v1.14.22

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/gobwas/ws v1.3.2/go.mod h1:hRKAFb8wOxFROYNsT1bqfWnhX+b5MFeJM9r2ZSwg/K
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogs/chardet v0.0.0-20211120154057-b7413eaefb8f h1:3BSP1Tbs2djlpprl7wCLuiqMaUh5SJkkzI2gDs+FgLs=
 github.com/gogs/chardet v0.0.0-20211120154057-b7413eaefb8f/go.mod h1:Pcatq5tYkCW2Q6yrR2VRHlbHpZ/R4/7qyL1TCF7vl14=
+github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
+github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -72,14 +72,14 @@ func ExpiresAt(t time.Time) option {
 	}
 }
 
-func Subject(sub string) option {
+func WithSubject(sub string) option {
 	return func(c *Claims) error {
 		c.Subject = sub
 		return nil
 	}
 }
 
-func Audience(aud string) option {
+func WithAudience(aud string) option {
 	return func(c *Claims) error {
 		c.Audience = []string{aud}
 		return nil
@@ -119,7 +119,7 @@ func (b *HMACBase64Key) UnmarshalText(text []byte) error {
 
 var parser *jwt.Parser
 
-func VerifyClaims(tokenString string, key HMACBase64Key) (*Claims, error) {
+func VerifyToken(tokenString string, key HMACBase64Key) (*Claims, error) {
 	if parser == nil {
 		parser = makeParser()
 	}

--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -1,0 +1,115 @@
+package auth
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+const (
+	Issuer = "scrape"
+)
+
+type option func(*Claims) error
+
+type Claims struct {
+	jwt.RegisteredClaims
+}
+
+func NewClaims(options ...option) (*Claims, error) {
+	c := &Claims{}
+	c.Issuer = Issuer
+	c.IssuedAt = jwt.NewNumericDate(time.Now())
+	c.NotBefore = jwt.NewNumericDate(time.Now())
+	for _, opt := range options {
+		if err := opt(c); err != nil {
+			return nil, err
+		}
+	}
+	if err := c.validate(); err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+func (c Claims) validate() error {
+	if c.Subject == "" {
+		return fmt.Errorf("subject is required")
+	}
+	return nil
+}
+
+func (c Claims) String() string {
+	val, err := json.MarshalIndent(c, "", "  ")
+	if err != nil {
+		return fmt.Sprintf("Error marshaling claims: %v", err)
+	}
+	return string(val)
+}
+
+func (c Claims) Token() *jwt.Token {
+	return jwt.NewWithClaims(jwt.SigningMethodHS256, c)
+}
+
+func (c Claims) Sign(key HMACBase64Key) (string, error) {
+	return c.Token().SignedString([]byte(key))
+}
+
+func ExpiresAt(t time.Time) option {
+	return func(c *Claims) error {
+		if t.Before(time.Now()) {
+			return fmt.Errorf("expiration time %v is in the past", t)
+		}
+		c.ExpiresAt = jwt.NewNumericDate(t)
+		return nil
+	}
+}
+
+func Subject(sub string) option {
+	return func(c *Claims) error {
+		c.Subject = sub
+		return nil
+	}
+}
+
+func Audience(aud string) option {
+	return func(c *Claims) error {
+		c.Audience = []string{aud}
+		return nil
+	}
+}
+
+func MustNewHS256SigningKey() HMACBase64Key {
+	key, err := NewHS256SigningKey()
+	if err != nil {
+		panic(err)
+	}
+	return key
+}
+
+func NewHS256SigningKey() (HMACBase64Key, error) {
+	key := make([]byte, 32)
+	_, err := rand.Read(key)
+	return HMACBase64Key(key), err
+}
+
+type HMACBase64Key []byte
+
+func (b HMACBase64Key) MarshalText() ([]byte, error) {
+	encoded := base64.StdEncoding.EncodeToString([]byte(b))
+	return []byte(encoded), nil
+}
+
+func (b *HMACBase64Key) UnmarshalText(text []byte) error {
+	decoded := make([]byte, base64.StdEncoding.DecodedLen(len(text)))
+	n, err := base64.StdEncoding.Decode(decoded, text)
+	if err != nil {
+		return err
+	}
+	*b = HMACBase64Key(decoded[:n])
+	return nil
+}

--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -1,3 +1,4 @@
+// JWT token generation and verification logic.
 package auth
 
 import (

--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -119,7 +119,9 @@ func (b *HMACBase64Key) UnmarshalText(text []byte) error {
 
 var parser *jwt.Parser
 
-func VerifyToken(tokenString string, key HMACBase64Key) (*Claims, error) {
+// VerifyToken verifies the token string using the provided key.
+// In the case where the token's signature is invalid, the function will not return any claims.
+func VerifyToken(key HMACBase64Key, tokenString string) (*Claims, error) {
 	if parser == nil {
 		parser = makeParser()
 	}

--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -25,7 +25,6 @@ func NewClaims(options ...option) (*Claims, error) {
 	c := &Claims{}
 	c.Issuer = Issuer
 	c.IssuedAt = jwt.NewNumericDate(time.Now())
-	c.NotBefore = jwt.NewNumericDate(time.Now())
 	for _, opt := range options {
 		if err := opt(c); err != nil {
 			return nil, err

--- a/internal/auth/jwt_test.go
+++ b/internal/auth/jwt_test.go
@@ -4,6 +4,8 @@ import (
 	"slices"
 	"testing"
 	"time"
+
+	"github.com/golang-jwt/jwt/v5"
 )
 
 func TestExpiresA(t *testing.T) {
@@ -99,19 +101,122 @@ func TestHMACBase64Key(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		k := HMACBase64Key(tt.input)
+		k := HMACBase64Key([]byte(tt.input))
 		encoded, err := k.MarshalText()
 		if err != nil {
-			t.Errorf("[%s] Unexpected error marshaling: %v", tt.name, err)
+			t.Fatalf("[%s] Unexpected error marshaling: %v", tt.name, err)
 		}
 		var kd HMACBase64Key
 		err = kd.UnmarshalText(encoded)
 		if err != nil {
-			t.Errorf("[%s] Unexpected error unmarshaling: %v", tt.name, err)
+			t.Fatalf("[%s] Unexpected error unmarshaling: %v", tt.name, err)
 		}
 		if !slices.Equal(k, kd) {
 			t.Errorf("[%s] Round-trip mismatch %q, got %q", tt.name, string(k), string(kd))
 		}
-		t.Logf("Encoded: %q", string(encoded))
+	}
+}
+
+func TestClaimsSignAndVerify(t *testing.T) {
+	t.Parallel()
+	defaultKey := MustNewHS256SigningKey()
+	baseClaims, _ := NewClaims(
+		ExpiresAt(time.Now().Add(24*time.Hour)),
+		Subject("test"),
+		Audience("test"),
+	)
+	var tests = []struct {
+		name      string
+		claimsF   func() Claims
+		key       HMACBase64Key
+		verifyKey HMACBase64Key
+		expectErr bool
+	}{
+		{
+			name: "valid claims and key",
+			claimsF: func() Claims {
+				c := *baseClaims
+				return c
+			},
+			key:       defaultKey,
+			verifyKey: defaultKey,
+			expectErr: false,
+		},
+		{
+			name: "invalid key",
+			claimsF: func() Claims {
+				c := *baseClaims
+				return c
+			},
+			key:       HMACBase64Key([]byte("invalid")),
+			verifyKey: defaultKey,
+			expectErr: true,
+		},
+		{
+			name: "expired claims",
+			claimsF: func() Claims {
+				c := *baseClaims
+				c.ExpiresAt = jwt.NewNumericDate(time.Now().Add(-24 * time.Hour))
+				return c
+			},
+			key:       defaultKey,
+			verifyKey: defaultKey,
+			expectErr: true,
+		},
+		{
+			name: "unsupported issuer",
+			claimsF: func() Claims {
+				c := *baseClaims
+				c.Issuer = "somebody else"
+				return c
+			},
+			key:       defaultKey,
+			verifyKey: defaultKey,
+			expectErr: true,
+		},
+		{
+			name: "no subject",
+			claimsF: func() Claims {
+				c := *baseClaims
+				c.Subject = ""
+				return c
+			},
+			key:       defaultKey,
+			verifyKey: defaultKey,
+			expectErr: true,
+		},
+	}
+	for _, tt := range tests {
+		claims := tt.claimsF()
+		key := tt.key
+		token, err := claims.Sign(key)
+		if err != nil {
+			t.Fatalf("Error signing claims: %v", err)
+		}
+		claims2, err := VerifyClaims(token, tt.verifyKey)
+		if (err != nil) != tt.expectErr {
+			t.Fatalf("[%s] Unexpected error state verifying claims: %v", tt.name, err)
+		}
+		if err != nil {
+			continue
+		}
+		if claims.Issuer != claims2.Issuer {
+			t.Errorf("Issuer mismatch %q, got %q", claims.Issuer, claims2.Issuer)
+		}
+		if claims.Subject != claims2.Subject {
+			t.Errorf("Subject mismatch %q, got %q", claims.Subject, claims2.Subject)
+		}
+		if claims.ExpiresAt.Unix() != claims2.ExpiresAt.Unix() {
+			t.Errorf("ExpiresAt mismatch %v, got %v", claims.ExpiresAt, claims2.ExpiresAt)
+		}
+		if !slices.Equal(claims.Audience, claims2.Audience) {
+			t.Errorf("Audience mismatch %v, got %v", claims.Audience, claims2.Audience)
+		}
+		if claims.IssuedAt.Unix() != claims2.IssuedAt.Unix() {
+			t.Errorf("IssuedAt mismatch %v, got %v", claims.IssuedAt, claims2.IssuedAt)
+		}
+		if claims.NotBefore.Unix() != claims2.NotBefore.Unix() {
+			t.Errorf("NotBefore mismatch %v, got %v", claims.NotBefore, claims2.NotBefore)
+		}
 	}
 }

--- a/internal/auth/jwt_test.go
+++ b/internal/auth/jwt_test.go
@@ -52,7 +52,7 @@ func TestSubject(t *testing.T) {
 	}
 	for _, tt := range tests {
 		c := &Claims{}
-		err := Subject(tt.sub)(c)
+		err := WithSubject(tt.sub)(c)
 		if err != nil {
 			t.Errorf("Unexpected error: %v", err)
 		}
@@ -75,7 +75,7 @@ func TestAudience(t *testing.T) {
 	}
 	for _, tt := range tests {
 		c := &Claims{}
-		err := Audience(tt.aud)(c)
+		err := WithAudience(tt.aud)(c)
 		if err != nil {
 			t.Errorf("Unexpected error: %v", err)
 		}
@@ -117,13 +117,13 @@ func TestHMACBase64Key(t *testing.T) {
 	}
 }
 
-func TestClaimsSignAndVerify(t *testing.T) {
+func TestSignAndVerify(t *testing.T) {
 	t.Parallel()
 	defaultKey := MustNewHS256SigningKey()
 	baseClaims, _ := NewClaims(
 		ExpiresAt(time.Now().Add(24*time.Hour)),
-		Subject("test"),
-		Audience("test"),
+		WithSubject("test"),
+		WithAudience("test"),
 	)
 	var tests = []struct {
 		name      string
@@ -188,12 +188,11 @@ func TestClaimsSignAndVerify(t *testing.T) {
 	}
 	for _, tt := range tests {
 		claims := tt.claimsF()
-		key := tt.key
-		token, err := claims.Sign(key)
+		token, err := claims.Sign(tt.key)
 		if err != nil {
 			t.Fatalf("Error signing claims: %v", err)
 		}
-		claims2, err := VerifyClaims(token, tt.verifyKey)
+		claims2, err := VerifyToken(token, tt.verifyKey)
 		if (err != nil) != tt.expectErr {
 			t.Fatalf("[%s] Unexpected error state verifying claims: %v", tt.name, err)
 		}

--- a/internal/auth/jwt_test.go
+++ b/internal/auth/jwt_test.go
@@ -214,8 +214,5 @@ func TestSignAndVerify(t *testing.T) {
 		if claims.IssuedAt.Unix() != claims2.IssuedAt.Unix() {
 			t.Errorf("IssuedAt mismatch %v, got %v", claims.IssuedAt, claims2.IssuedAt)
 		}
-		if claims.NotBefore.Unix() != claims2.NotBefore.Unix() {
-			t.Errorf("NotBefore mismatch %v, got %v", claims.NotBefore, claims2.NotBefore)
-		}
 	}
 }

--- a/internal/auth/jwt_test.go
+++ b/internal/auth/jwt_test.go
@@ -192,7 +192,7 @@ func TestSignAndVerify(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Error signing claims: %v", err)
 		}
-		claims2, err := VerifyToken(token, tt.verifyKey)
+		claims2, err := VerifyToken(tt.verifyKey, token)
 		if (err != nil) != tt.expectErr {
 			t.Fatalf("[%s] Unexpected error state verifying claims: %v", tt.name, err)
 		}

--- a/internal/auth/jwt_test.go
+++ b/internal/auth/jwt_test.go
@@ -1,0 +1,117 @@
+package auth
+
+import (
+	"slices"
+	"testing"
+	"time"
+)
+
+func TestExpiresA(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		t         time.Time
+		expectErr bool
+	}{
+		{
+			name:      "future time",
+			t:         time.Now().Add(24 * time.Hour),
+			expectErr: false,
+		},
+		{
+			name:      "past time",
+			t:         time.Now().Add(-24 * time.Hour),
+			expectErr: true,
+		},
+	}
+	for _, tt := range tests {
+
+		c := &Claims{}
+		err := ExpiresAt(tt.t)(c)
+		if tt.expectErr && err == nil {
+			t.Errorf("Expected error, got nil")
+		}
+		if !tt.expectErr && err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+	}
+}
+
+func TestSubject(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		sub  string
+	}{
+		{
+			name: "valid subject",
+			sub:  "test",
+		},
+	}
+	for _, tt := range tests {
+		c := &Claims{}
+		err := Subject(tt.sub)(c)
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+		if c.Subject != tt.sub {
+			t.Errorf("Expected subject %q, got %q", tt.sub, c.Subject)
+		}
+	}
+}
+
+func TestAudience(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		aud  string
+	}{
+		{
+			name: "valid audience",
+			aud:  "test",
+		},
+	}
+	for _, tt := range tests {
+		c := &Claims{}
+		err := Audience(tt.aud)(c)
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+		if c.Audience[0] != tt.aud {
+			t.Errorf("Expected audience %q, got %q", tt.aud, c.Audience[0])
+		}
+	}
+}
+
+func TestHMACBase64Key(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		input []byte
+	}{
+		{
+			name:  "simple key",
+			input: []byte("test"),
+		},
+		{
+			name:  "random key",
+			input: MustNewHS256SigningKey(),
+		},
+	}
+	for _, tt := range tests {
+		k := HMACBase64Key(tt.input)
+		encoded, err := k.MarshalText()
+		if err != nil {
+			t.Errorf("[%s] Unexpected error marshaling: %v", tt.name, err)
+		}
+		var kd HMACBase64Key
+		err = kd.UnmarshalText(encoded)
+		if err != nil {
+			t.Errorf("[%s] Unexpected error unmarshaling: %v", tt.name, err)
+		}
+		if !slices.Equal(k, kd) {
+			t.Errorf("[%s] Round-trip mismatch %q, got %q", tt.name, string(k), string(kd))
+		}
+		t.Logf("Encoded: %q", string(encoded))
+	}
+}

--- a/internal/auth/jwt_test.go
+++ b/internal/auth/jwt_test.go
@@ -27,7 +27,6 @@ func TestExpiresA(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-
 		c := &Claims{}
 		err := ExpiresAt(tt.t)(c)
 		if tt.expectErr && err == nil {


### PR DESCRIPTION
## Background: 
This PR is the first in a set of changes adding authorization capabilities to scrape to support access [over the open internet] from both AWS (for Pocket) and Outerbounds GCP clusters (for ML). 

The recommended approach was to use Google's IAP auth proxy. I spent some with the docs/tooling -- it's a bit complicated and apparently non-trivial to up. 

At the same time, using IAP and also requires the ability to make and verify JWT tooling in an app that uses it so I'm building those pieces, which can also provide an generic authorization token capability with or without IAP. We'll get to IAP in a later step.

## What's here:
This PR adds a package to scrape to create, sign, verify and decode JWTs, along with a pair of shell commands (`scrape-jwt-encode` and `scrape-jwt-decode`) to generate HS256 secret encode/sign and decode/verify tokens from the command line.

The JWT claims themselves are pretty minimal, containing the essentials of what you need to implement API consumer-type authorization (`sub` for the consumer you're issuing the key to, an expiration time, etc.)

This PR does not change any facet of authorization for a running service instance, that will come in a later PR. 

## Steps to test
### Getting Started
1. Checkout this branch
2. From the repo root, run `make`

To run the unit tests, run `make test`. To test the new shell commands, read on.

All of the test steps use the `scrape-jwt-encode` and `scrape-jwt-decode` binaries. You can get complete help for these by invoking either with `-h`.

### Making an HS256 secret key

1. `./build/scrape-jwt-encode -make-key`

The app will print out a base64 encoded string representing a cryptographically random 256 bit key. 

For the next tests, you'll need to pass that secret to the apps to encode and decode JWT keys. The easiest way to do that is to:

1. Set an environment variable called `SCRAPE_SIGNING_KEY` to the base64 string from the above step. (e.g. `export SCRAPE_SIGNING_KEY=8q6R97jhw4cH6PExQ8MvWoANfBbA97CsAA3lsZfmo2Q=`) 

### Encode a JWT key

1. `./build/scrape-jwt-encode -sub pr-test`

You should see a result like this: 

```
./build/scrape-jwt-encode -sub pr-test                                

Claims:
------
{
  "iss": "scrape",
  "sub": "pr-test",
  "aud": [
    "moz"
  ],
  "exp": 1747083931,
  "iat": 1715547931
}

Token:
-----
eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzY3JhcGUiLCJzdWIiOiJzb21lb25lIiwiYXVkIjpbIm1veiJdLCJleHAiOjE3NDcxMDUwNzQsImlhdCI6MTcxNTU2OTA3NH0.YqDlwXXNgwQXN_EBeKe5_UMBiOy18cUEjBKJxLzkHUk
```

The echoed token contains the claims listed above them, signed with with key that was generated in the above test.

Copy this token to your clipboard, you will use it in the next test.

### Decode a JWT key

```
./build/scrape-jwt-decode eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzY3JhcGUiLCJzdWIiOiJzb21lb25lIiwiYXVkIjpbIm1veiJdLCJleHAiOjE3NDcxMDUwNzQsImlhdCI6MTcxNTU2OTA3NH0.YqDlwXXNgwQXN_EBeKe5_UMBiOy18cUEjBKJxLzkHUk
```
Output should show the claims matching the above: 

```
This JWT is valid. Claims:
------
{
  "iss": "scrape",
  "sub": "pr-test",
  "aud": [
    "moz"
  ],
  "exp": 1747083931,
  "iat": 1715547931
}
```




