### PR TITLE
Prep test console for auth keys

### DIFF
--- a/cmd/scrape-jwt-decode/main.go
+++ b/cmd/scrape-jwt-decode/main.go
@@ -1,0 +1,65 @@
+// scrape-jwt-decode verifies and decodes auth keys for the scrape service
+//
+// Run `scrape-jwt-decode -h` for complete help and command line options.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/efixler/envflags"
+	"github.com/efixler/scrape/internal/auth"
+)
+
+var (
+	flags      flag.FlagSet
+	signingKey *envflags.Value[*auth.HMACBase64Key]
+)
+
+func main() {
+	token := flags.Arg(0)
+	key := *signingKey.Get()
+	if len(key) == 0 {
+		slog.Error("No signing key provided")
+		os.Exit(1)
+	}
+	claims, err := auth.VerifyToken(key, token)
+	if err != nil {
+		slog.Error("Error verifying token, the token or signature are invalid", "err", err)
+		os.Exit(1)
+	}
+	fmt.Println("\nThis JWT is valid. Claims:\n------")
+	fmt.Println(claims)
+}
+
+func init() {
+	flags.Init("scrape-jwt-encode", flag.ExitOnError)
+	flags.Usage = usage
+	envflags.EnvPrefix = "SCRAPE_"
+	signingKey = envflags.NewText("SIGNING_KEY", &auth.HMACBase64Key{})
+	signingKey.AddTo(&flags, "signing-key", "HS256 key to sign the JWT token")
+	flags.Parse(os.Args[1:])
+	if len(flags.Args()) == 0 {
+		slog.Error("Token is required")
+		usage()
+		os.Exit(1)
+	}
+}
+
+func usage() {
+	fmt.Println(`
+Verify and decode scrape JWT tokens.
+
+Signing key is required to verify the token signature. The signing key should be base64
+encoded and can be provided as a command line flag or environment variable.
+
+Usage: 
+-----
+scrape-jwt-decode [-signing-key keyval] token
+	`)
+
+	flags.PrintDefaults()
+}

--- a/cmd/scrape-jwt-encode/main.go
+++ b/cmd/scrape-jwt-encode/main.go
@@ -1,0 +1,106 @@
+// scrape-jwt-encode generates auth keys for the scrape service
+//
+// Run `scrape-jwt-encode -h` for complete help and command line options.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"log/slog"
+
+	"github.com/efixler/envflags"
+	"github.com/efixler/scrape/internal/auth"
+)
+
+var (
+	flags      flag.FlagSet
+	expires    = time.Now().Add(24 * time.Hour * 365)
+	subject    string
+	audience   = "moz"
+	signingKey *envflags.Value[*auth.HMACBase64Key]
+	makeKey    bool
+)
+
+func main() {
+	if makeKey {
+		makeSigningKey()
+		return
+	}
+	makeToken()
+}
+
+func makeToken() {
+	if subject == "" {
+		slog.Error("Subject is required")
+		usage()
+		os.Exit(1)
+	}
+	claims, err := auth.NewClaims(
+		auth.ExpiresAt(expires),
+		auth.WithSubject(subject),
+		auth.WithAudience(audience),
+	)
+	if err != nil {
+		slog.Error("Error generating claims", "err", err)
+		os.Exit(1)
+	}
+	fmt.Println("\nClaims:\n------")
+	fmt.Println(claims)
+	key := *signingKey.Get()
+	if len(key) == 0 {
+		slog.Warn("No signing key provided, cannot sign token, exiting")
+		os.Exit(1)
+	}
+	ss, err := claims.Sign(key)
+	if err != nil {
+		slog.Error("Error signing token", "err", err)
+		os.Exit(1)
+	}
+	fmt.Println("\nToken:\n-----")
+	fmt.Println(ss)
+}
+
+func makeSigningKey() {
+	key, err := auth.NewHS256SigningKey()
+	if err != nil {
+		slog.Error("Error generating signing key", "err", err)
+		os.Exit(1)
+	}
+	encoded, err := key.MarshalText()
+	if err != nil {
+		slog.Error("Error encoding signing key", "err", err)
+		os.Exit(1)
+	}
+	fmt.Println("Be sure to save this key, as it can't be re-generated:")
+	fmt.Println(string(encoded))
+}
+
+func init() {
+	flags.Init("scrape-jwt-encode", flag.ExitOnError)
+	flags.Usage = usage
+	envflags.EnvPrefix = "SCRAPE_"
+	flags.BoolVar(&makeKey, "make-key", false, "Generate a new signing key")
+	flags.TextVar(&expires, "exp", expires, "Expiration date for the key, in RFC3339 format. Default is 1 year from now.")
+	flags.StringVar(&subject, "sub", "", "Subject (holder name) for the key (required)")
+	flags.StringVar(&audience, "aud", audience, "Audience (recipient) for the key")
+	signingKey = envflags.NewText("SIGNING_KEY", &auth.HMACBase64Key{})
+	signingKey.AddTo(&flags, "signing-key", "HS256 key to sign the JWT token")
+	flags.Parse(os.Args[1:])
+}
+
+func usage() {
+	fmt.Println(`
+Generates JWT tokens for the scrape service. Also makes the signing key to use for the tokens.
+
+Usage: 
+-----
+scrape-jwt-encode -sub subject [-signing-key key] [-exp expiration] [-aud audience]
+scrape-jwt-encode -make-key
+	`)
+
+	flags.PrintDefaults()
+}

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/efixler/webutil v0.0.0-20240331165905-2fd0e608a9e9
 	github.com/go-shiori/go-readability v0.0.0-20240204090920-819593fddc6b
 	github.com/go-sql-driver/mysql v1.8.1
+	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/markusmobius/go-domdistiller v0.0.0-20230515154422-71af71939ff3
 	github.com/markusmobius/go-trafilatura v1.5.1
 	github.com/mattn/go-sqlite3 v1.14.22

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/gobwas/ws v1.3.2/go.mod h1:hRKAFb8wOxFROYNsT1bqfWnhX+b5MFeJM9r2ZSwg/K
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogs/chardet v0.0.0-20211120154057-b7413eaefb8f h1:3BSP1Tbs2djlpprl7wCLuiqMaUh5SJkkzI2gDs+FgLs=
 github.com/gogs/chardet v0.0.0-20211120154057-b7413eaefb8f/go.mod h1:Pcatq5tYkCW2Q6yrR2VRHlbHpZ/R4/7qyL1TCF7vl14=
+github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
+github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -1,0 +1,149 @@
+// JWT token generation and verification logic.
+package auth
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+const (
+	Issuer = "scrape"
+)
+
+type option func(*Claims) error
+
+type Claims struct {
+	jwt.RegisteredClaims
+}
+
+func NewClaims(options ...option) (*Claims, error) {
+	c := &Claims{}
+	c.Issuer = Issuer
+	c.IssuedAt = jwt.NewNumericDate(time.Now())
+	for _, opt := range options {
+		if err := opt(c); err != nil {
+			return nil, err
+		}
+	}
+	if err := c.Validate(); err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+// Implements the jwt.ClaimsValidator interface
+// In addition to the explicit call when the claims are created,
+// this method is called by ParseWithClaims when the token is parsed.
+func (c Claims) Validate() error {
+	if c.Subject == "" {
+		return fmt.Errorf("subject is required")
+	}
+	return nil
+}
+
+func (c Claims) String() string {
+	val, err := json.MarshalIndent(c, "", "  ")
+	if err != nil {
+		return fmt.Sprintf("error stringifying claims: %v", err)
+	}
+	return string(val)
+}
+
+func (c Claims) Token() *jwt.Token {
+	return jwt.NewWithClaims(jwt.SigningMethodHS256, c)
+}
+
+func (c Claims) Sign(key HMACBase64Key) (string, error) {
+	return c.Token().SignedString([]byte(key))
+}
+
+func ExpiresAt(t time.Time) option {
+	return func(c *Claims) error {
+		if t.Before(time.Now()) {
+			return fmt.Errorf("expiration time %v is in the past", t)
+		}
+		c.ExpiresAt = jwt.NewNumericDate(t)
+		return nil
+	}
+}
+
+func WithSubject(sub string) option {
+	return func(c *Claims) error {
+		c.Subject = sub
+		return nil
+	}
+}
+
+func WithAudience(aud string) option {
+	return func(c *Claims) error {
+		c.Audience = []string{aud}
+		return nil
+	}
+}
+
+func MustNewHS256SigningKey() HMACBase64Key {
+	key, err := NewHS256SigningKey()
+	if err != nil {
+		panic(err)
+	}
+	return key
+}
+
+func NewHS256SigningKey() (HMACBase64Key, error) {
+	key := make([]byte, 32)
+	_, err := rand.Read(key)
+	return HMACBase64Key(key), err
+}
+
+type HMACBase64Key []byte
+
+func (b HMACBase64Key) MarshalText() ([]byte, error) {
+	encoded := base64.StdEncoding.EncodeToString([]byte(b))
+	return []byte(encoded), nil
+}
+
+func (b *HMACBase64Key) UnmarshalText(text []byte) error {
+	decoded := make([]byte, base64.StdEncoding.DecodedLen(len(text)))
+	n, err := base64.StdEncoding.Decode(decoded, text)
+	if err != nil {
+		return err
+	}
+	*b = HMACBase64Key(decoded[:n])
+	return nil
+}
+
+var parser *jwt.Parser
+
+// VerifyToken verifies the token string using the provided key.
+// In the case where the token's signature is invalid, the function will not return any claims.
+func VerifyToken(key HMACBase64Key, tokenString string) (*Claims, error) {
+	if parser == nil {
+		parser = makeParser()
+	}
+	token, err := parser.ParseWithClaims(tokenString, &Claims{}, func(token *jwt.Token) (interface{}, error) {
+		return []byte(key), nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	claims, ok := token.Claims.(*Claims)
+	if !ok {
+		return nil, fmt.Errorf("unexpected claims type: %T", token.Claims)
+	}
+	return claims, nil
+}
+
+func makeParser() *jwt.Parser {
+	parser := jwt.NewParser(
+		jwt.WithIssuer(Issuer),
+		jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Name}),
+		jwt.WithLeeway(1*time.Minute),
+		jwt.WithIssuedAt(),
+	)
+	return parser
+}

--- a/internal/auth/jwt_test.go
+++ b/internal/auth/jwt_test.go
@@ -1,0 +1,217 @@
+package auth
+
+import (
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+func TestExpiresA(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		t         time.Time
+		expectErr bool
+	}{
+		{
+			name:      "future time",
+			t:         time.Now().Add(24 * time.Hour),
+			expectErr: false,
+		},
+		{
+			name:      "past time",
+			t:         time.Now().Add(-24 * time.Hour),
+			expectErr: true,
+		},
+	}
+	for _, tt := range tests {
+		c := &Claims{}
+		err := ExpiresAt(tt.t)(c)
+		if tt.expectErr && err == nil {
+			t.Errorf("Expected error, got nil")
+		}
+		if !tt.expectErr && err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+	}
+}
+
+func TestSubject(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		sub  string
+	}{
+		{
+			name: "valid subject",
+			sub:  "test",
+		},
+	}
+	for _, tt := range tests {
+		c := &Claims{}
+		err := WithSubject(tt.sub)(c)
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+		if c.Subject != tt.sub {
+			t.Errorf("Expected subject %q, got %q", tt.sub, c.Subject)
+		}
+	}
+}
+
+func TestAudience(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		aud  string
+	}{
+		{
+			name: "valid audience",
+			aud:  "test",
+		},
+	}
+	for _, tt := range tests {
+		c := &Claims{}
+		err := WithAudience(tt.aud)(c)
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+		if c.Audience[0] != tt.aud {
+			t.Errorf("Expected audience %q, got %q", tt.aud, c.Audience[0])
+		}
+	}
+}
+
+func TestHMACBase64Key(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		input []byte
+	}{
+		{
+			name:  "simple key",
+			input: []byte("test"),
+		},
+		{
+			name:  "random key",
+			input: MustNewHS256SigningKey(),
+		},
+	}
+	for _, tt := range tests {
+		k := HMACBase64Key([]byte(tt.input))
+		encoded, err := k.MarshalText()
+		if err != nil {
+			t.Fatalf("[%s] Unexpected error marshaling: %v", tt.name, err)
+		}
+		var kd HMACBase64Key
+		err = kd.UnmarshalText(encoded)
+		if err != nil {
+			t.Fatalf("[%s] Unexpected error unmarshaling: %v", tt.name, err)
+		}
+		if !slices.Equal(k, kd) {
+			t.Errorf("[%s] Round-trip mismatch %q, got %q", tt.name, string(k), string(kd))
+		}
+	}
+}
+
+func TestSignAndVerify(t *testing.T) {
+	t.Parallel()
+	defaultKey := MustNewHS256SigningKey()
+	baseClaims, _ := NewClaims(
+		ExpiresAt(time.Now().Add(24*time.Hour)),
+		WithSubject("test"),
+		WithAudience("test"),
+	)
+	var tests = []struct {
+		name      string
+		claimsF   func() Claims
+		key       HMACBase64Key
+		verifyKey HMACBase64Key
+		expectErr bool
+	}{
+		{
+			name: "valid claims and key",
+			claimsF: func() Claims {
+				c := *baseClaims
+				return c
+			},
+			key:       defaultKey,
+			verifyKey: defaultKey,
+			expectErr: false,
+		},
+		{
+			name: "invalid key",
+			claimsF: func() Claims {
+				c := *baseClaims
+				return c
+			},
+			key:       HMACBase64Key([]byte("invalid")),
+			verifyKey: defaultKey,
+			expectErr: true,
+		},
+		{
+			name: "expired claims",
+			claimsF: func() Claims {
+				c := *baseClaims
+				c.ExpiresAt = jwt.NewNumericDate(time.Now().Add(-24 * time.Hour))
+				return c
+			},
+			key:       defaultKey,
+			verifyKey: defaultKey,
+			expectErr: true,
+		},
+		{
+			name: "unsupported issuer",
+			claimsF: func() Claims {
+				c := *baseClaims
+				c.Issuer = "somebody else"
+				return c
+			},
+			key:       defaultKey,
+			verifyKey: defaultKey,
+			expectErr: true,
+		},
+		{
+			name: "no subject",
+			claimsF: func() Claims {
+				c := *baseClaims
+				c.Subject = ""
+				return c
+			},
+			key:       defaultKey,
+			verifyKey: defaultKey,
+			expectErr: true,
+		},
+	}
+	for _, tt := range tests {
+		claims := tt.claimsF()
+		token, err := claims.Sign(tt.key)
+		if err != nil {
+			t.Fatalf("Error signing claims: %v", err)
+		}
+		claims2, err := VerifyToken(tt.verifyKey, token)
+		if (err != nil) != tt.expectErr {
+			t.Fatalf("[%s] Unexpected error state verifying claims: %v", tt.name, err)
+		}
+		if err != nil {
+			continue
+		}
+		if claims.Issuer != claims2.Issuer {
+			t.Errorf("Issuer mismatch %q, got %q", claims.Issuer, claims2.Issuer)
+		}
+		if claims.Subject != claims2.Subject {
+			t.Errorf("Subject mismatch %q, got %q", claims.Subject, claims2.Subject)
+		}
+		if claims.ExpiresAt.Unix() != claims2.ExpiresAt.Unix() {
+			t.Errorf("ExpiresAt mismatch %v, got %v", claims.ExpiresAt, claims2.ExpiresAt)
+		}
+		if !slices.Equal(claims.Audience, claims2.Audience) {
+			t.Errorf("Audience mismatch %v, got %v", claims.Audience, claims2.Audience)
+		}
+		if claims.IssuedAt.Unix() != claims2.IssuedAt.Unix() {
+			t.Errorf("IssuedAt mismatch %v, got %v", claims.IssuedAt, claims2.IssuedAt)
+		}
+	}
+}

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -47,7 +47,11 @@ func isJSON(r *http.Request) bool {
 	if r.Method == http.MethodGet {
 		return false
 	}
-	if strings.HasPrefix(r.Header.Get("Content-Type"), "application/x-www-form-urlencoded") {
+	contentType := strings.SplitN(r.Header.Get("Content-Type"), ";", 2)[0]
+	switch contentType {
+	case "application/x-www-form-urlencoded":
+		return false
+	case "multipart/form-data":
 		return false
 	}
 	return true

--- a/internal/server/middleware_test.go
+++ b/internal/server/middleware_test.go
@@ -214,3 +214,55 @@ func TestParseSinglePostForm(t *testing.T) {
 		}
 	}
 }
+
+func TestIsJson(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		content  string
+		expected bool
+	}{
+		{
+			name:     "json",
+			content:  "application/json",
+			expected: true,
+		},
+		{
+			name:     "json with charset",
+			content:  "application/json; charset=utf-8",
+			expected: true,
+		},
+		{
+			name:     "json with other",
+			content:  "application/json; foo=bar",
+			expected: true,
+		},
+		{
+			name:     "x-www-form-urlencoded, no addons",
+			content:  "application/x-www-form-urlencoded",
+			expected: false,
+		},
+		{
+			name:     "x-www-form-urlencoded, with charset",
+			content:  "application/x-www-form-urlencoded; charset=utf-8",
+			expected: false,
+		},
+		{
+			name:     "multipart, no addons",
+			content:  "multipart/form-data",
+			expected: false,
+		},
+		{
+			name:     "multipart, with charset",
+			content:  "multipart/form-data; charset=utf-8",
+			expected: false,
+		},
+	}
+	for _, tt := range tests {
+		req := httptest.NewRequest("POST", "http://example.com", nil)
+		req.Header.Set("Content-Type", tt.content)
+		if isJSON(req) != tt.expected {
+			t.Fatalf("[%s] isJSON, expected %v, got %v", tt.name, tt.expected, !tt.expected)
+		}
+	}
+}

--- a/internal/server/pages/index.html
+++ b/internal/server/pages/index.html
@@ -12,11 +12,18 @@
 		label {
   			margin: 0.2rem 0;
 		}
+		.data-iframe {
+  			position: relative;
+  			top: 16px; 
+  			width: 98%;
+  			min-width: 768px;
+  			height: calc(100vh - 108px); 
+		}
 	</style>
 </head>
 <body>
 <p>
-<form id="urlForm" action="/extract" method="POST" name="scrape" target="data_frame">
+<form id="urlForm" action="/extract" method="POST" name="scrape" target="data-iframe">
 <label for="url">Enter a URL:</label>
 <input type="submit" value="Hit It">
 <input type="url" name="url" id="url" value="https://" size="96" maxlength="200" pattern="https?://.*" required title="URL">
@@ -35,13 +42,49 @@ function updateFormAction() {
     document.getElementById("urlForm").action = selected;
 }
 </script>
-<div style="padding-top:16px;">
+<script type="text/javascript">
+	document.addEventListener('DOMContentLoaded', function() {
+		const iframe = document.getElementById('data');
+		iframe.contentDocument.body.innerHTML = '';
+		const preElement = document.createElement('pre');
+		preElement.style.whiteSpace = 'pre-wrap';
+		preElement.style.width = '100%';
+		iframe.contentDocument.body.appendChild(preElement);
+		const form = document.getElementById('urlForm');
+		form.addEventListener('submit', async function(event) {
+			event.preventDefault();
+			const action = form.action;
+			const headers = new Headers();
+			headers.append('Authorization', 'Bearer not_implemented_yet');
+			const formData = new FormData(form);
+
+			try { 
+			const response = await fetch(action, {
+				method: 'POST',
+				headers: headers,
+				body: formData
+			})
+			if (response.ok) {
+				const json = await response.json();
+				const jsonStr = JSON.stringify(json, null, 2);
+				preElement.textContent = jsonStr;
+			} else {
+				const text = await response.text();
+				preElement.textContent = `Error ${response.status}:\n${text}`;
+				throw new Error(`${response.status} - ${text}`);
+			}
+		} catch (error) {
+			console.error(error);
+		}
+	});
+});
+	</script>
+<div>
 <iframe 
 	id="data"
 	title="Scrape Results"
-	name="data_frame"
-	width="1024"
-	height="1024"
+	name="data-iframe"
+	class="data-iframe"
 	>
 
 </div>


### PR DESCRIPTION
## Background

This PR is part of a series adding JWT based authorization to the scrape service.  The authentication is primarily aimed at API access, but we need to consider access for the root path as well, which provides a tool to spot check scrape results for individual urls or RSS feeds. The ACLs for this page will likely be a little different than for the API, in the sense that we'll want access to this to be more permissive, for convenience. Parts of that are still TBD; this PR provides the hook that we'll use to pass an authentication token from this page back to the relevant endpoints.

## What's here

This PR changes the way the root page's form is submitted; it's now being submitted via a Javascript event handler, so that we can, in the future, submit an authorization token as a header along with that request. Authorization itself is not changed here. (There _are_ a couple of minor cosmetic changes)

One backend change was needed to make this work - when submitting an HTML form without JS the default content type is `application/x-www-form-urlencoded`. When doing that same operation with the JS `fetch()` call, the content type is `multipart-form-data`. A function that was checking the inbound content type needed to be updated for this case (tests were added here too).

## Steps to test

From the root folder of this branch:

1. `make` (if you don't have go installed, you can alternately `make docker-build` followed by `make docker-run`
2. Navigate to http://localhost:8080
3. Enter some URLs and 'Hit It', you should see results in the textarea.

